### PR TITLE
(#4) Added option to Include File URL in schema.

### DIFF
--- a/packages/core/src/components/Uploader/Uploader.tsx
+++ b/packages/core/src/components/Uploader/Uploader.tsx
@@ -22,6 +22,10 @@ export interface UploaderProps {
    * Whether or not we should use the file's name when uploading
    */
   storeOriginalFilename?: boolean
+  /**
+   * Whether or not to include the file URL in the Sanity document. This is useful if file URLs needs to be validated before fetched. This defaults to true.
+   */
+  includeFileURL?: boolean
 
   // FIELD INPUT CONTEXT
   /**

--- a/packages/core/src/components/Uploader/useUpload.tsx
+++ b/packages/core/src/components/Uploader/useUpload.tsx
@@ -25,6 +25,7 @@ const useUpload = ({
   vendorConfig,
   sanityClient,
   storeOriginalFilename = true,
+  includeFileURL = true,
   onSuccess,
 }: UploaderProps): useUploadReturn => {
   const toast = useToast()
@@ -51,6 +52,7 @@ const useUpload = ({
             file: context.file as File,
             storeOriginalFilename,
           }),
+          includeFileURL,
           onError: (error) =>
             callback({
               type: 'VENDOR_ERROR',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,6 +50,10 @@ export interface VendorConfiguration {
      */
     fileName: string
     /**
+     * Whether or not to include the file URL in the Sanity document. This is useful if file URLs needs to be validated before fetched. This defaults to true.
+     */
+    includeFileURL: boolean
+    /**
      * Credentials as configured by your plugin.
      */
     credentials: VendorCredentials

--- a/packages/firebase/src/config.ts
+++ b/packages/firebase/src/config.ts
@@ -53,6 +53,7 @@ const config: VendorConfiguration = {
     onSuccess,
     file,
     fileName,
+    includeFileURL,
     updateProgress,
   }) => {
     const firebaseClient = getFirebaseClient(credentials as FirebaseCredentials)
@@ -76,11 +77,14 @@ const config: VendorConfiguration = {
         onError(error)
       },
       async () => {
-        const downloadURL = await uploadTask.snapshot.ref.getDownloadURL()
+        let downloadURL: string | null = null
+        if (includeFileURL) {
+          downloadURL = await uploadTask.snapshot.ref.getDownloadURL()
+        }
         const metadata = await uploadTask.snapshot.ref.getMetadata()
 
         onSuccess({
-          fileURL: downloadURL,
+          fileURL: includeFileURL ? downloadURL : null,
           firebase: {
             bucket: metadata.bucket,
             contentDisposition: metadata.contentDisposition,


### PR DESCRIPTION
In response to the issue I made   (#4):

I added a potential option that allows the File URLS to be removed from the schema, the Firebase DAM, for example, came with an authorization token in the URL that allows anyone to view it despite the rules set. I've only edited the Firebase DAM to have the option to include File URL.

I couldn't test this on a running sanity website, though I plan to try on Monday. This is a small, non-breaking change.

I'm open for suggestions. Also, I should also add a guide on README.md about the new option.