### PR TITLE
(#6) Allow users to upload additional file types

### DIFF
--- a/packages/aws/src/config.ts
+++ b/packages/aws/src/config.ts
@@ -1,4 +1,4 @@
-import pluginConfig from 'config:s3-dam';
+import pluginConfig from 'config:s3-dam?';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import {
   LockIcon,

--- a/packages/aws/src/config.ts
+++ b/packages/aws/src/config.ts
@@ -1,3 +1,4 @@
+import pluginConfig from 'config:s3-dam';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import {
   LockIcon,
@@ -12,11 +13,13 @@ export const DEFAULT_ACCEPT = [
   'audio/*',
 ]
 
+const { defaultAccept, toolTitle } = pluginConfig ?? {};
+
 const config: VendorConfiguration = {
-  id: 's3-dam',  
+  id: 's3-dam',
   customDataFieldName: 's3',
-  defaultAccept: DEFAULT_ACCEPT,
-  toolTitle: 'Videos & audio (S3)',
+  defaultAccept: defaultAccept ?? DEFAULT_ACCEPT,
+  toolTitle: toolTitle ?? 'Videos & audio (S3)',
   credentialsFields: [
     {
       name: 'bucketKey',

--- a/packages/aws/src/partTypes.d.ts
+++ b/packages/aws/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:s3-dam'
+declare module 'config:s3-dam?'

--- a/packages/core/src/components/Uploader/uploadMachine.ts
+++ b/packages/core/src/components/Uploader/uploadMachine.ts
@@ -300,6 +300,20 @@ const uploadMachine = createMachine<Context, UploadEvent>(
           ],
         },
         {
+          target: 'uploadingToVendor',
+          cond: (_context, event, { state }) =>
+            (['idle', 'failure'].some(state.matches) &&
+              event.file?.type != null) ||
+            false,
+          actions: [
+            assign({
+              file: (_context, event) => {
+                return event.file
+              },
+            }),
+          ],
+        },
+        {
           // Else, show a toast
           actions: 'invalidFileToast',
         },

--- a/packages/digital-ocean/src/config.ts
+++ b/packages/digital-ocean/src/config.ts
@@ -1,4 +1,4 @@
-import pluginConfig from 'config:digital-ocean-files';
+import pluginConfig from 'config:digital-ocean-files?';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import {
   LockIcon,

--- a/packages/digital-ocean/src/config.ts
+++ b/packages/digital-ocean/src/config.ts
@@ -1,3 +1,4 @@
+import pluginConfig from 'config:digital-ocean-files';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import {
   LockIcon,
@@ -10,11 +11,13 @@ import {
 
 export const DEFAULT_ACCEPT = ['video/*', 'audio/*']
 
+const { defaultAccept, toolTitle } = pluginConfig ?? {};
+
 const config: VendorConfiguration = {
   id: 'digital-ocean-files',
   customDataFieldName: 'digitalOcean',
-  defaultAccept: DEFAULT_ACCEPT,
-  toolTitle: 'Videos & audio (DigitalOcean)',
+  defaultAccept: defaultAccept ?? DEFAULT_ACCEPT,
+  toolTitle: toolTitle ?? 'Videos & audio (DigitalOcean)',
   credentialsFields: [
     {
       name: 'bucketKey',

--- a/packages/digital-ocean/src/partTypes.d.ts
+++ b/packages/digital-ocean/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:digital-ocean-files'
+declare module 'config:digital-ocean-files?'

--- a/packages/digital-ocean/src/partTypes.d.ts
+++ b/packages/digital-ocean/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:digital-ocean-files?'
+declare module 'config:digital-ocean-files'

--- a/packages/firebase/src/config.ts
+++ b/packages/firebase/src/config.ts
@@ -1,4 +1,4 @@
-import pluginConfig from 'config:firebase-dam';
+import pluginConfig from 'config:firebase-dam?';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import { LockIcon, LinkIcon } from '@sanity/icons'
 import getFirebaseClient, { FirebaseCredentials } from './getFirebaseClient'

--- a/packages/firebase/src/config.ts
+++ b/packages/firebase/src/config.ts
@@ -1,3 +1,4 @@
+import pluginConfig from 'config:firebase-dam';
 import { VendorConfiguration } from 'sanity-plugin-external-dam/lib/types'
 import { LockIcon, LinkIcon } from '@sanity/icons'
 import getFirebaseClient, { FirebaseCredentials } from './getFirebaseClient'
@@ -7,11 +8,13 @@ export const DEFAULT_ACCEPT = [
   'audio/*',
 ]
 
+const { defaultAccept, toolTitle } = pluginConfig ?? {};
+
 const config: VendorConfiguration = {
   id: 'firebase-dam',
   customDataFieldName: 'firebase',
-  defaultAccept: DEFAULT_ACCEPT,
-  toolTitle: "Videos & Audio (Firebase)",
+  defaultAccept: defaultAccept ?? DEFAULT_ACCEPT,
+  toolTitle: toolTitle ?? "Videos & Audio (Firebase)",
   supportsProgress: true,
   credentialsFields: [
     {

--- a/packages/firebase/src/partTypes.d.ts
+++ b/packages/firebase/src/partTypes.d.ts
@@ -1,1 +1,1 @@
-declare module 'config:firebase-dam'
+declare module 'config:firebase-dam?'


### PR DESCRIPTION
# Description

- I've exposed `defaultAccept` and `toolTitle` as plugin configuration options. For example:
`config/s3-dam.json`
```json
{
    "toolTitle": "S3 Media",
    "defaultAccept": ["application/pdf", "image/*", "audio/*", "video/*"]
}
```
- In order to accept non-video and non-audio files, I've added a new state to the `uploadMachine` as a fallback
- I haven't added thumbnails or previews to any new file types, but I've adjusted the `MediaPreview` component's internal logic to accommodate more file types.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

